### PR TITLE
Update SequelPostgres adapter for new version of valkyrie_sequel.

### DIFF
--- a/lib/valkyrie_benchmark/metadata_adapters/sequel_postgres.rb
+++ b/lib/valkyrie_benchmark/metadata_adapters/sequel_postgres.rb
@@ -3,8 +3,10 @@ module ValkyrieBenchmark
   module MetadataAdapters
     class SequelPostgres < BaseAdapter
 
-      def valkyrie_adapter
-        @valkyrie_adapter ||= Valkyrie::Sequel::MetadataAdapter.new(config['db'].symbolize_keys)
+      def valkyrie_adapter        
+        @valkyrie_adapter ||= Valkyrie::Sequel::MetadataAdapter.new(
+          connection: Sequel.connect(config['db'].symbolize_keys.merge(adapter: :postgres))
+        )
       end
 
       def migrate


### PR DESCRIPTION
Connection is now passed directly instead of all connection parameters in a hash.